### PR TITLE
Run tests and linters with Github Actions CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,53 @@
+name: tests-and-linters
+
+on:
+  - pull_request
+  - push
+
+jobs:
+  test:
+    name: Run tests
+    strategy:
+      matrix:
+        go-version:
+          - 1.15
+          - 1.16
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Test
+        run: go test ./...
+
+  super-linter:
+    name: Run Super-Linter
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Run Super-Linter
+        uses: github/super-linter@v3
+        env:
+          DEFAULT_BRANCH: master
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_GO: false # Go linting is broken for now, see: https://github.com/github/super-linter/issues/143
+          VALIDATE_JSCPD: false # TODO(dfurman): consider configuring this linter
+
+  golangci-lint:
+    name: Run golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.37

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,7 @@
+run:
+  build-tags:
+    - examples
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+# TODO(dfurman): enable more linters

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Run tests: `go test ./...`
 
 Run all tests, including usage examples: `go test -tags examples ./...`
 
+Install linters runner: [golangci-lint local installation](https://golangci-lint.run/usage/install/#local-installation)  
+Run golangci-lint: `golangci-lint run ./...`
+
 ## Development state
 
 Finished implementation:

--- a/examples/run_example.sh
+++ b/examples/run_example.sh
@@ -9,15 +9,15 @@ function stage() {
     BLUE_BOLD="\e[1m\e[34m"
     RESET="\e[0m"
     msg="$1"
-    
+
     echo
     echo -e "$BLUE_BOLD$msg$RESET"
 }
 
 if [[ $1 != "" ]]; then
     stage "Running single example: $1"
-    go test -tags examples -count 1 -run $1  ./... -v
-else 
+    go test -tags examples -count 1 -run "$1"  ./... -v
+else
     stage "Running all examples"
     go test -tags examples -count 1 ./... -v
 fi

--- a/kentikapi/gen_enum.sh
+++ b/kentikapi/gen_enum.sh
@@ -4,7 +4,7 @@ function stage() {
     COLOR="\e[95m"
     RESET="\e[0m"
     msg="$1"
-    
+
     echo
     echo -e "$COLOR$msg$RESET"
 }
@@ -13,6 +13,7 @@ function checkPrerequsites() {
     stage "Checking prerequisites"
 
     which enumer > /dev/null 2>&1
+    # shellcheck disable=SC2181
     [[ $? != 0 ]] && echo "You need to install enumer with: go get github.com/alvaroloes/enumer" && exit 1
 
     echo "OK"
@@ -21,7 +22,7 @@ function checkPrerequsites() {
 function genEnums() {
     stage "Generating enums"
 
-    cd models/
+    cd models/ || exit 1
     enumer -output enum_myenumtype.go  -type MyEnumType # update output and type to your enum
 
     echo "OK"

--- a/kentikapi/internal/api_payloads/device.go
+++ b/kentikapi/internal/api_payloads/device.go
@@ -336,19 +336,6 @@ func payloadToDeviceLabel(p deviceLabelPayload) (models.DeviceLabel, error) {
 	}, nil
 }
 
-// nolint: deadcode, unused
-func deviceLabelToPayload(d models.DeviceLabel) (deviceLabelPayload, error) {
-	return deviceLabelPayload{
-		ID:          d.ID,
-		Name:        d.Name,
-		Color:       d.Color,
-		UserID:      d.UserID,
-		CompanyID:   d.CompanyID,
-		CreatedDate: d.CreatedDate,
-		UpdatedDate: d.UpdatedDate,
-	}, nil
-}
-
 // deviceSitePayload represents JSON Device.Site payload as it is transmitted from KentikAPI.
 // deviceSitePayload embeddedd under Device differs from regular SitePayload in that all fields are optional.
 type deviceSitePayload struct {

--- a/kentikapi/internal/api_payloads/device.go
+++ b/kentikapi/internal/api_payloads/device.go
@@ -336,6 +336,7 @@ func payloadToDeviceLabel(p deviceLabelPayload) (models.DeviceLabel, error) {
 	}, nil
 }
 
+// nolint: deadcode, unused
 func deviceLabelToPayload(d models.DeviceLabel) (deviceLabelPayload, error) {
 	return deviceLabelPayload{
 		ID:          d.ID,

--- a/kentikapi/internal/api_resources/devices_test.go
+++ b/kentikapi/internal/api_resources/devices_test.go
@@ -1,6 +1,7 @@
 package api_resources_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -112,7 +113,7 @@ func TestCreateDeviceRouter(t *testing.T) {
 	models.SetOptional(&router.DeviceBGPPassword, "bgp-optional-password")
 	models.SetOptional(&router.SiteID, 8483)
 	models.SetOptional(&router.DeviceBGPFlowSpec, true)
-	device, err := devicesAPI.Create(nil, *router)
+	device, err := devicesAPI.Create(context.Background(), *router)
 
 	// assert request properly formed
 	assert := assert.New(t)
@@ -283,7 +284,7 @@ func TestCreateDeviceDNS(t *testing.T) {
 	models.SetOptional(&dns.DeviceDescription, "testapi dns with minimal config")
 	models.SetOptional(&dns.SiteID, 8483)
 	models.SetOptional(&dns.DeviceBGPFlowSpec, true)
-	device, err := devicesAPI.Create(nil, *dns)
+	device, err := devicesAPI.Create(context.Background(), *dns)
 
 	// assert request properly formed
 	assert := assert.New(t)
@@ -455,7 +456,7 @@ func TestUpdatetDeviceRouter(t *testing.T) {
 	models.SetOptional(&router.DeviceBGPNeighborIPv6, "2001:db8:85a3:8d3:1319:8a2e:370:7348")
 	models.SetOptional(&router.DeviceBGPPassword, "bgp-optional-password")
 	models.SetOptional(&router.DeviceBGPFlowSpec, true)
-	device, err := devicesAPI.Update(nil, router)
+	device, err := devicesAPI.Update(context.Background(), router)
 
 	// assert request properly formed
 	assert := assert.New(t)
@@ -516,7 +517,7 @@ func TestUpdatetDeviceRouter(t *testing.T) {
 	assert.Equal(0, len(device.Labels))
 	assert.Equal(0, len(device.AllInterfaces))
 	assert.Equal("auto", *device.DeviceFlowType)
-	assert.Equal(10, *&device.DeviceSampleRate)
+	assert.Equal(10, device.DeviceSampleRate)
 	assert.Equal(2, len(device.SendingIPS))
 	assert.Equal("128.0.0.10", device.SendingIPS[0])
 	assert.Equal("128.0.0.11", device.SendingIPS[1])
@@ -668,7 +669,7 @@ func TestGetDeviceRouter(t *testing.T) {
 	deviceID := models.ID(42)
 
 	// act
-	device, err := devicesAPI.Get(nil, deviceID)
+	device, err := devicesAPI.Get(context.Background(), deviceID)
 
 	// assert request properly formed
 	assert := assert.New(t)
@@ -730,7 +731,7 @@ func TestGetDeviceRouter(t *testing.T) {
 	assert.Equal(models.ID(42), device.AllInterfaces[1].DeviceID)
 	assert.Equal(7.0, device.AllInterfaces[1].SNMPSpeed)
 	assert.Equal("auto", *device.DeviceFlowType)
-	assert.Equal(1001, *&device.DeviceSampleRate)
+	assert.Equal(1001, device.DeviceSampleRate)
 	assert.Equal(2, len(device.SendingIPS))
 	assert.Equal("128.0.0.11", device.SendingIPS[0])
 	assert.Equal("128.0.0.12", device.SendingIPS[1])
@@ -826,7 +827,7 @@ func TestGetDeviceDNS(t *testing.T) {
 	deviceID := models.ID(43)
 
 	// act
-	device, err := devicesAPI.Get(nil, deviceID)
+	device, err := devicesAPI.Get(context.Background(), deviceID)
 
 	// assert request properly formed
 	assert := assert.New(t)
@@ -1057,7 +1058,7 @@ func TestGetAllDevices(t *testing.T) {
 	devicesAPI := api_resources.NewDevicesAPI(transport)
 
 	// act
-	devices, err := devicesAPI.GetAll(nil)
+	devices, err := devicesAPI.GetAll(context.Background())
 
 	// assert request properly formed
 	assert := assert.New(t)
@@ -1114,7 +1115,7 @@ func TestGetAllDevices(t *testing.T) {
 	assert.Equal("#5289D9", device.Labels[1].Color)
 	require.Equal(0, len(device.AllInterfaces))
 	assert.Equal("auto", *device.DeviceFlowType)
-	assert.Equal(1001, *&device.DeviceSampleRate)
+	assert.Equal(1001, device.DeviceSampleRate)
 	assert.Equal(2, len(device.SendingIPS))
 	assert.Equal("128.0.0.11", device.SendingIPS[0])
 	assert.Equal("128.0.0.12", device.SendingIPS[1])
@@ -1157,7 +1158,7 @@ func TestDeleteDevice(t *testing.T) {
 
 	// act
 	deviceID := models.ID(42)
-	err := devicesAPI.Delete(nil, deviceID)
+	err := devicesAPI.Delete(context.Background(), deviceID)
 
 	// assert
 	assert := assert.New(t)
@@ -1207,7 +1208,7 @@ func TestApplyLabels(t *testing.T) {
 	// act
 	deviceID := models.ID(42)
 	labels := []models.ID{models.ID(3011), models.ID(3012)}
-	result, err := devicesAPI.ApplyLabels(nil, deviceID, labels)
+	result, err := devicesAPI.ApplyLabels(context.Background(), deviceID, labels)
 
 	// assert request properly formed
 	assert := assert.New(t)
@@ -1274,7 +1275,7 @@ func TestGetInterfaceMinimal(t *testing.T) {
 	// act
 	deviceID := models.ID(42)
 	interfaceID := models.ID(43)
-	intf, err := devicesAPI.Interfaces.Get(nil, deviceID, interfaceID)
+	intf, err := devicesAPI.Interfaces.Get(context.Background(), deviceID, interfaceID)
 
 	// assert request properly formed
 	assert := assert.New(t)
@@ -1375,7 +1376,7 @@ func TestGetInterfaceFull(t *testing.T) {
 	// act
 	deviceID := models.ID(42)
 	interfaceID := models.ID(43)
-	intf, err := devicesAPI.Interfaces.Get(nil, deviceID, interfaceID)
+	intf, err := devicesAPI.Interfaces.Get(context.Background(), deviceID, interfaceID)
 
 	// assert request properly formed
 	assert := assert.New(t)
@@ -1560,7 +1561,7 @@ func TestGetAllInterfaces(t *testing.T) {
 
 	// act
 	deviceID := models.ID(42)
-	interfaces, err := devicesAPI.Interfaces.GetAll(nil, deviceID)
+	interfaces, err := devicesAPI.Interfaces.GetAll(context.Background(), deviceID)
 
 	// assert request properly formed
 	assert := assert.New(t)
@@ -1632,7 +1633,7 @@ func TestCreateInterfaceMinimal(t *testing.T) {
 		8,
 		"testapi-interface-2",
 	)
-	created, err := devicesAPI.Interfaces.Create(nil, *intf)
+	created, err := devicesAPI.Interfaces.Create(context.Background(), *intf)
 
 	// assert request properly formed
 	assert := assert.New(t)
@@ -1713,7 +1714,7 @@ func TestCreateInterfaceFull(t *testing.T) {
 	models.SetOptional(&intf.InterfaceIPNetmask, "255.255.255.0")
 	intf.SecondaryIPS = []models.SecondaryIP{secondaryIP1, secondaryIP2}
 	intf.VRF = vrf
-	created, err := devicesAPI.Interfaces.Create(nil, *intf)
+	created, err := devicesAPI.Interfaces.Create(context.Background(), *intf)
 
 	// assert request properly formed
 	assert := assert.New(t)
@@ -1767,7 +1768,7 @@ func TestDeleteInterface(t *testing.T) {
 	// act
 	deviceID := models.ID(42)
 	interfaceID := models.ID(43)
-	err := devicesAPI.Interfaces.Delete(nil, deviceID, interfaceID)
+	err := devicesAPI.Interfaces.Delete(context.Background(), deviceID, interfaceID)
 
 	// assert
 	assert := assert.New(t)
@@ -1817,7 +1818,7 @@ func TestUpdatenteInterfaceMinimal(t *testing.T) {
 	deviceID := models.ID(42)
 	interfaceID := models.ID(43)
 	intf := models.Interface{SNMPSpeed: 75, DeviceID: deviceID, ID: interfaceID}
-	updated, err := devicesAPI.Interfaces.Update(nil, intf)
+	updated, err := devicesAPI.Interfaces.Update(context.Background(), intf)
 
 	// assert request properly formed
 	assert := assert.New(t)
@@ -1909,7 +1910,7 @@ func TestUpdatenteInterfaceFull(t *testing.T) {
 	models.SetOptional(&intf.InterfaceIP, "127.0.44.55")
 	models.SetOptional(&intf.InterfaceIPNetmask, "255.255.255.0")
 	intf.VRF = vrf
-	updated, err := devicesAPI.Interfaces.Update(nil, intf)
+	updated, err := devicesAPI.Interfaces.Update(context.Background(), intf)
 
 	// assert request properly formed
 	assert := assert.New(t)


### PR DESCRIPTION
Use Super-Linter to run multiple static analysis tools for multiple files.
Use golangci-lint for the Go code
Fix code to comply to linters

Note that "test" job could use Actions caching functionality to cache downloaded
Go modules and Go build cache. This improvement could be configured in
the future.

Issue: KNTK-182