### PR TITLE
Allow to enable debug logs in APIv6 client

### DIFF
--- a/apiv6/kentikapi/client.go
+++ b/apiv6/kentikapi/client.go
@@ -52,6 +52,7 @@ func makeCloudExportConfig(c Config) *cloudexport.Configuration {
 	cfg.Servers[0].URL = c.CloudExportAPIURL
 	cfg.Servers[0].Description = "Kentik CloudExport server"
 
+	cfg.Debug = c.Debug
 	return cfg
 }
 
@@ -66,6 +67,7 @@ func makeSyntheticsConfig(c Config) *synthetics.Configuration {
 	cfg.Servers[0].URL = c.SyntheticsAPIURL
 	cfg.Servers[0].Description = "Kentik Synthetics server"
 
+	cfg.Debug = c.Debug
 	return cfg
 }
 
@@ -75,4 +77,6 @@ type Config struct {
 	SyntheticsAPIURL  string // if blank, default api url will be used
 	AuthEmail         string
 	AuthToken         string
+	// Debug logs for requests and responses
+	Debug             bool
 }

--- a/apiv6/localhost_apiserver/synthetics/go/repo.go
+++ b/apiv6/localhost_apiserver/synthetics/go/repo.go
@@ -74,8 +74,6 @@ func (r *SyntheticsRepo) CreateTest(t V202101beta1Test) (*V202101beta1Test, erro
 	newTest := t
 	newTest.Id = r.allocateNewTestID()
 	newTest.Cdate = time.Now()
-	newTest.Settings.TargetType = ""
-	newTest.Settings.TargetValue = ""
 
 	r.tests = append(r.tests, newTest)
 	r.save()


### PR DESCRIPTION
Also do not reset target_type and target_value in localhost_apiserver.

Issue: KNTK-245