### PR TITLE
Retrying client to retry on temporary errors

### DIFF
--- a/apiv6/kentikapi/httputil/httputil_test.go
+++ b/apiv6/kentikapi/httputil/httputil_test.go
@@ -1,0 +1,120 @@
+package httputil
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Sequence of calls for single request:
+// 1. retryingClient.Do()
+// 2. retryingClient.retryableRoundTripper.RoundTrip()
+// 3. retryingClient.retryableRoundTripper.retryableClient.Do()
+// 4. retryingClient.retryableRoundTripper.retryableClient.httpClient.Do()
+// 5. retryingClient.retryableRoundTripper.retryableClient.httpClient.httpTransport.RoundTrip()
+
+func TestRetryingClient_Do_ReturnsHTTPTransportError(t *testing.T) {
+	// arrange
+	c := NewRetryingClient(ClientConfig{})
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://invalid.url", nil)
+	require.NoError(t, err)
+
+	// act
+	resp, err := c.Do(req)
+
+	// assert
+	t.Logf("Got response: %v, err: %v", resp, err)
+
+	var dnsErr *net.DNSError
+	require.True(t, errors.As(err, &dnsErr))
+	assert.Equal(t, "no such host", dnsErr.Err)
+}
+
+func TestRetryingClientWithSpyHTTPTransport_Do(t *testing.T) {
+	const retryMax = 5
+
+	tests := []struct {
+		name                  string
+		transportError        error
+		expectedRequestsCount int
+	}{
+		{
+			name: "retries when underlying client returns temporary URL error",
+			transportError: &url.Error{
+				Err: &net.OpError{
+					Err: &net.DNSError{
+						Err:         "fake error",
+						IsTemporary: true,
+					},
+				},
+			},
+			expectedRequestsCount: retryMax + 1,
+		}, {
+			name: "does not retry when underlying client returns non-temporary URL error",
+			transportError: &url.Error{
+				Err: &net.OpError{
+					Err: &net.DNSError{
+						Err:         "fake error",
+						IsTemporary: false,
+					},
+				},
+			},
+			expectedRequestsCount: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// arrange
+
+			st := spyTransport{transportError: tt.transportError}
+			c := NewRetryingClient(ClientConfig{
+				HTTPClient: &http.Client{
+					Transport: &st,
+				},
+				RetryMax:     intPtr(retryMax),
+				RetryWaitMin: durationPtr(1 * time.Microsecond),
+				RetryWaitMax: durationPtr(10 * time.Microsecond),
+			})
+
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://dummy.url", nil)
+			require.NoError(t, err)
+
+			// act
+			resp, err := c.Do(req)
+
+			// assert
+			t.Logf("Got response: %v, err: %v", resp, err)
+			assert.Equal(t, tt.expectedRequestsCount, st.requestsCount)
+
+			var dnsErr *net.DNSError
+			require.True(t, errors.As(err, &dnsErr))
+			assert.Equal(t, "fake error", dnsErr.Err)
+		})
+	}
+}
+
+type spyTransport struct {
+	transportError error
+	requestsCount  int
+}
+
+func (t *spyTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
+	t.requestsCount++
+	return nil, t.transportError
+}
+
+func intPtr(v int) *int {
+	return &v
+}
+
+func durationPtr(v time.Duration) *time.Duration {
+	return &v
+}


### PR DESCRIPTION
Improve retrying client retry policy not to panic when transport returns
and error.
If error is not temporary, do not retry.
Improve test coverage.

Issue: KNTK-268
