### PR TITLE
Run golangci-lint on examples

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run Super-Linter
-        uses: github/super-linter@v3
+        uses: github/super-linter@v3.17.0
         env:
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,7 @@
 run:
   build-tags:
     - examples
+  skip-dirs-use-default: false
 
 issues:
   max-issues-per-linter: 0

--- a/examples/alerting_example_test.go
+++ b/examples/alerting_example_test.go
@@ -1,6 +1,7 @@
 //go:build examples
 // +build examples
 
+//nolint:testpackage,forbidigo
 package examples
 
 import (

--- a/examples/cloud_export_example_test.go
+++ b/examples/cloud_export_example_test.go
@@ -1,6 +1,7 @@
 //go:build examples
 // +build examples
 
+//nolint:testpackage,forbidigo
 package examples
 
 import (
@@ -37,7 +38,7 @@ func runGRPCCRUDCloudExport() error {
 		Name:          "test_gce_export",
 		PlanId:        "11467",
 		CloudProvider: "gce",
-		Properties:    &cloudexportpb.CloudExport_Gce{gce},
+		Properties:    &cloudexportpb.CloudExport_Gce{Gce: gce},
 	}
 	createReqPayload := &cloudexportpb.CreateCloudExportRequest{Export: export}
 

--- a/examples/custom_applications_example_test.go
+++ b/examples/custom_applications_example_test.go
@@ -1,6 +1,7 @@
 //go:build examples
 // +build examples
 
+//nolint:testpackage,forbidigo
 package examples
 
 import (

--- a/examples/custom_dimensions_example_test.go
+++ b/examples/custom_dimensions_example_test.go
@@ -1,6 +1,7 @@
 //go:build examples
 // +build examples
 
+//nolint:testpackage,forbidigo
 package examples
 
 import (
@@ -127,6 +128,7 @@ func runCRUDCustomDimensions() error {
 	return nil
 }
 
+//nolint: gosec // no need for cryptographically secure RNG here
 func randID() string {
 	rand.Seed(time.Now().UnixNano())
 	chars := []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")

--- a/examples/demos/client_merge_demo/main.go
+++ b/examples/demos/client_merge_demo/main.go
@@ -1,20 +1,20 @@
+//nolint:forbidigo
 package main
 
 import (
 	"context"
 	"errors"
 	"fmt"
-	syntheticspb "github.com/kentik/api-schema-public/gen/go/kentik/synthetics/v202101beta1"
 	"log"
 	"os"
 
+	syntheticspb "github.com/kentik/api-schema-public/gen/go/kentik/synthetics/v202101beta1"
 	"github.com/kentik/community_sdk_golang/examples/demos"
 	"github.com/kentik/community_sdk_golang/kentikapi"
 )
 
 func main() {
-	err := showClientMerge()
-	if err != nil {
+	if err := showClientMerge(); err != nil {
 		log.Fatal(err)
 	}
 }
@@ -34,11 +34,14 @@ func showClientMerge() error {
 		AuthToken: token,
 	})
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	demos.Step("List users using API v5")
 	result, err := c.Users.GetAll(context.Background())
+	if err != nil {
+		return err
+	}
 
 	fmt.Println("Received result:")
 	demos.PrettyPrint(result)
@@ -47,7 +50,7 @@ func showClientMerge() error {
 	getResp, err := c.SyntheticsAdmin.ListAgents(context.Background(), &syntheticspb.ListAgentsRequest{})
 
 	fmt.Println("Received result:")
-	demos.PrettyPrint(getResp)
+	demos.PrettyPrint(getResp.GetAgents())
 
 	return err
 }

--- a/examples/demos/devices_users_demo/main.go
+++ b/examples/demos/devices_users_demo/main.go
@@ -1,3 +1,4 @@
+//nolint:forbidigo
 package main
 
 import (
@@ -34,6 +35,7 @@ func main() {
 	demos.Step("Finished!")
 }
 
+//nolint:gomnd
 func createDevice(client *kentikapi.Client) models.ID {
 	device := models.NewDeviceDNS(
 		"testapi_dns_awssubnet",
@@ -47,7 +49,7 @@ func createDevice(client *kentikapi.Client) models.ID {
 
 	createdDevice, err := client.Devices.Create(context.Background(), *device)
 	demos.ExitOnError(err)
-	fmt.Printf("Successfuly created device, ID = %d\n", createdDevice.ID)
+	fmt.Printf("Successfully created device, ID = %d\n", createdDevice.ID)
 
 	return createdDevice.ID
 }

--- a/examples/demos/grpc_synthetics_demo/main.go
+++ b/examples/demos/grpc_synthetics_demo/main.go
@@ -1,3 +1,4 @@
+//nolint:forbidigo
 package main
 
 import (
@@ -13,12 +14,12 @@ import (
 )
 
 func main() {
-	err := showGRPCClient()
-	if err != nil {
+	if err := showGRPCClient(); err != nil {
 		log.Fatal(err)
 	}
 }
 
+//nolint:gomnd
 func showGRPCClient() error {
 	email, token, err := examples.ReadCredentialsFromEnv()
 	if err != nil {
@@ -34,8 +35,8 @@ func showGRPCClient() error {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	ctx, close := context.WithTimeout(context.Background(), 100*time.Second)
-	defer close()
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Second)
+	defer cancel()
 
 	demos.Step("List synthetic agents")
 	result, err := c.SyntheticsAdmin.ListAgents(ctx, &synthetics.ListAgentsRequest{})

--- a/examples/demos/interfaces_query_demo/main.go
+++ b/examples/demos/interfaces_query_demo/main.go
@@ -1,3 +1,4 @@
+//nolint:forbidigo
 package main
 
 import (
@@ -45,6 +46,7 @@ func main() {
 	queryChart(client)
 }
 
+//nolint:gomnd
 func createDevice(client *kentikapi.Client) models.ID {
 	device := models.NewDeviceDNS(
 		"interfaces_query_demo_device",
@@ -55,11 +57,12 @@ func createDevice(client *kentikapi.Client) models.ID {
 	)
 	createdDevice, err := client.Devices.Create(context.Background(), *device)
 	demos.ExitOnError(err)
-	fmt.Printf("Successfuly created device, ID = %d\n", createdDevice.ID)
+	fmt.Printf("Successfully created device, ID = %d\n", createdDevice.ID)
 
 	return createdDevice.ID
 }
 
+//nolint:gomnd
 func createInterface(client *kentikapi.Client, deviceID models.ID) models.ID {
 	intf := models.NewInterface(
 		deviceID,
@@ -69,16 +72,16 @@ func createInterface(client *kentikapi.Client, deviceID models.ID) models.ID {
 	)
 	createdInterface, err := client.Devices.Interfaces.Create(context.Background(), *intf)
 	demos.ExitOnError(err)
-	fmt.Printf("Successfuly created interface, ID = %d\n", createdInterface.ID)
+	fmt.Printf("Successfully created interface, ID = %d\n", createdInterface.ID)
 
 	return createdInterface.ID
 }
 
 func getInterface(client *kentikapi.Client, deviceID, interfaceID models.ID) {
 	fmt.Printf("Retrieving interface, deviceID = %d, interfaceID = %d\n", deviceID, interfaceID)
-	interface_, err := client.Devices.Interfaces.Get(context.Background(), deviceID, interfaceID)
+	i, err := client.Devices.Interfaces.Get(context.Background(), deviceID, interfaceID)
 	demos.ExitOnError(err)
-	demos.PrettyPrint(interface_)
+	demos.PrettyPrint(i)
 }
 
 func deleteInterface(client *kentikapi.Client, deviceID, interfaceID models.ID) {
@@ -103,6 +106,7 @@ func deleteDevice(client *kentikapi.Client, deviceID models.ID) {
 	fmt.Println("Successful")
 }
 
+//nolint:gomnd
 func queryData(client *kentikapi.Client) {
 	// prepare query
 	agg1 := models.NewAggregate("avg_bits_per_sec", "f_sum_both_bytes", models.AggregateFunctionTypeAverage)
@@ -137,6 +141,7 @@ func queryData(client *kentikapi.Client) {
 	demos.DisplayQueryDataResult(result)
 }
 
+//nolint:gomnd
 func queryChart(client *kentikapi.Client) {
 	// prepare query
 	agg1 := models.NewAggregate("avg_bits_per_sec", "f_sum_both_bytes", models.AggregateFunctionTypeAverage)

--- a/examples/demos/interfaces_query_demo/main.go
+++ b/examples/demos/interfaces_query_demo/main.go
@@ -138,7 +138,8 @@ func queryData(client *kentikapi.Client) {
 	fmt.Println("Done.")
 
 	// display result
-	demos.DisplayQueryDataResult(result)
+	err = demos.DisplayQueryDataResult(result)
+	demos.ExitOnError(err)
 }
 
 //nolint:gomnd

--- a/examples/demos/retry_apiv5_demo/main.go
+++ b/examples/demos/retry_apiv5_demo/main.go
@@ -1,3 +1,4 @@
+//nolint:forbidigo
 package main
 
 import (
@@ -21,6 +22,7 @@ func main() {
 	}
 }
 
+//nolint:gomnd
 func showRetryingOnMultipleCodes() error {
 	demos.Step("Create fake Kentik API server")
 	h := newSpyHTTPHandler([]httpResponse{
@@ -44,9 +46,9 @@ func showRetryingOnMultipleCodes() error {
 	c, err := kentikapi.NewClient(kentikapi.Config{
 		APIURL: s.URL,
 		RetryCfg: kentikapi.RetryConfig{
-			MaxAttempts:          uintPtr(42),
-			MinDelay:             durationPtr(1 * time.Second),
-			MaxDelay:             durationPtr(2 * time.Second),
+			MaxAttempts: uintPtr(42),
+			MinDelay:    durationPtr(1 * time.Second),
+			MaxDelay:    durationPtr(2 * time.Second),
 		},
 	})
 	if err != nil {
@@ -92,7 +94,7 @@ func (h *spyHTTPHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 
 	h.requests = append(h.requests, httpRequest{
 		method: r.Method,
-		url_:   r.URL,
+		url:    r.URL,
 		header: r.Header,
 		body:   string(body),
 	})
@@ -105,8 +107,7 @@ func (h *spyHTTPHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 
 func writeResponse(rw http.ResponseWriter, statusCode int, body string) {
 	rw.WriteHeader(statusCode)
-	_, err := rw.Write([]byte(body))
-	if err != nil {
+	if _, err := rw.Write([]byte(body)); err != nil {
 		log.Printf("spyHTTPHandler: failed to write response body: %v", err)
 	}
 }
@@ -127,7 +128,7 @@ func (h *spyHTTPHandler) response() httpResponse {
 
 type httpRequest struct {
 	method string
-	url_   *url.URL
+	url    *url.URL
 	header http.Header
 	body   string
 }

--- a/examples/demos/utils.go
+++ b/examples/demos/utils.go
@@ -1,8 +1,10 @@
+//nolint:forbidigo
 package demos
 
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"os/exec"
 	"text/tabwriter"
@@ -12,13 +14,14 @@ import (
 	"github.com/kentik/community_sdk_golang/kentikapi/models"
 )
 
+//nolint:gochecknoglobals
 var (
 	ExitOnError = examples.PanicOnError
 	PrettyPrint = examples.PrettyPrint
 	NewClient   = examples.NewClient
 )
 
-// untypedData allows trawersing untyped structures made of maps and slices
+// untypedData allows trawersing untyped structures made of maps and slices.
 type untypedData struct {
 	V interface{}
 }
@@ -27,14 +30,19 @@ func makeUntypedData(v interface{}) untypedData {
 	return untypedData{V: v}
 }
 
+// TODO: test this file thoroughly. Previous code didn't panic so ok should be true.
 func (d untypedData) object(key string) untypedData {
-	m := d.V.(map[string]interface{})
-	return untypedData{V: m[key]}
+	if m, ok := d.V.(map[string]interface{}); ok {
+		return untypedData{V: m[key]}
+	}
+	return untypedData{V: nil}
 }
 
 func (d untypedData) item(index int) untypedData {
-	l := d.V.([]interface{})
-	return untypedData{V: l[index]}
+	if l, ok := d.V.([]interface{}); ok {
+		return untypedData{V: l[index]}
+	}
+	return untypedData{V: nil}
 }
 
 func Step(msg string) {
@@ -44,33 +52,46 @@ func Step(msg string) {
 	fmt.Println()
 	fmt.Printf("%s%s%s\n", blueBold, msg, reset)
 	fmt.Printf("Press enter to continue...")
-	fmt.Scanln()
+	if _, err := fmt.Scanln(); err != nil {
+		log.Fatal(err)
+	}
 }
 
-// DisplayQueryDataResult prints returned data series in form of a table
+//nolint:gomnd
+// DisplayQueryDataResult prints returned data series in form of a table.
 func DisplayQueryDataResult(r models.QueryDataResult) {
 	const printoutTableFormat = "%v\t%v\t\n" // bits/sec, datetime
 
-	timeSeries := makeUntypedData(r.Results[0]).object("data").item(0).object("timeSeries").object("both_bits_per_sec").object("flow").V.([]interface{})
+	if timeSeries, ok := makeUntypedData(r.Results[0]).
+		object("data").
+		item(0).
+		object("timeSeries").
+		object("both_bits_per_sec").
+		object("flow").
+		V.([]interface{}); ok {
+		w := makeTabWriter()
 
-	w := makeTabWriter(printoutTableFormat)
+		// print table header
+		fmt.Fprintf(w, printoutTableFormat, "avg_bits_per_sec", "time")
+		fmt.Fprintf(w, printoutTableFormat, "----------------", "----")
 
-	// print table header
-	fmt.Fprintf(w, printoutTableFormat, "avg_bits_per_sec", "time")
-	fmt.Fprintf(w, printoutTableFormat, "----------------", "----")
-
-	// print table rows
-	for _, ts := range timeSeries {
-		timeBitsPeriod := ts.([]interface{})
-		unixTime := int64(timeBitsPeriod[0].(float64)) / 1000 // API returns time in milliseconds, we need seconds
-		avgBitsPerSecond := int64(timeBitsPeriod[1].(float64))
-		fmt.Fprintf(w, printoutTableFormat, avgBitsPerSecond, time.Unix(unixTime, 0))
+		// print table rows
+		for _, ts := range timeSeries {
+			if timeBitsPeriod, ok := ts.([]interface{}); ok {
+				unixTime := int64(timeBitsPeriod[0].(float64)) / 1000 // API returns time in milliseconds, we need seconds
+				avgBitsPerSecond := int64(timeBitsPeriod[1].(float64))
+				fmt.Fprintf(w, printoutTableFormat, avgBitsPerSecond, time.Unix(unixTime, 0))
+			}
+		}
+		err := w.Flush()
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
-	w.Flush()
 }
 
-// makeTabWriter prepares tabwriter for writing file list in form: Name  Size  Type
-func makeTabWriter(format string) *tabwriter.Writer {
+// makeTabWriter prepares tabwriter for writing file list in form: Name  Size  Type.
+func makeTabWriter() *tabwriter.Writer {
 	const minWidth = 0  // minimal cell width including any padding
 	const tabWidth = 2  // width of tab characters (equivalent number of spaces)
 	const padding = 4   // distance between cells
@@ -80,7 +101,8 @@ func makeTabWriter(format string) *tabwriter.Writer {
 	return w
 }
 
-// DisplayQueryChartResult shows returned chart image
+//nolint:gosec // G204: Subprocess launched with a potential tainted input or cmd arguments - not an issue
+// DisplayQueryChartResult shows returned chart image.
 func DisplayQueryChartResult(r models.QueryChartResult) error {
 	// generate temp filename
 	file, err := ioutil.TempFile("", "chart_*."+r.ImageType.String())
@@ -88,7 +110,10 @@ func DisplayQueryChartResult(r models.QueryChartResult) error {
 		return err
 	}
 
-	r.SaveImageAs(file.Name())
+	err = r.SaveImageAs(file.Name())
+	if err != nil {
+		log.Fatal(err)
+	}
 	cmd := exec.Command("firefox", file.Name())
 	return cmd.Run()
 }

--- a/examples/demos/utils.go
+++ b/examples/demos/utils.go
@@ -30,7 +30,6 @@ func makeUntypedData(v interface{}) untypedData {
 	return untypedData{V: v}
 }
 
-// TODO: test this file thoroughly. Previous code didn't panic so ok should be true.
 func (d untypedData) object(key string) untypedData {
 	if m, ok := d.V.(map[string]interface{}); ok {
 		return untypedData{V: m[key]}
@@ -53,13 +52,13 @@ func Step(msg string) {
 	fmt.Printf("%s%s%s\n", blueBold, msg, reset)
 	fmt.Printf("Press enter to continue...")
 	if _, err := fmt.Scanln(); err != nil {
-		log.Fatal(err)
+		log.Print(err)
 	}
 }
 
 //nolint:gomnd
 // DisplayQueryDataResult prints returned data series in form of a table.
-func DisplayQueryDataResult(r models.QueryDataResult) {
+func DisplayQueryDataResult(r models.QueryDataResult) error {
 	const printoutTableFormat = "%v\t%v\t\n" // bits/sec, datetime
 
 	if timeSeries, ok := makeUntypedData(r.Results[0]).
@@ -85,9 +84,10 @@ func DisplayQueryDataResult(r models.QueryDataResult) {
 		}
 		err := w.Flush()
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 	}
+	return nil
 }
 
 // makeTabWriter prepares tabwriter for writing file list in form: Name  Size  Type.
@@ -112,7 +112,7 @@ func DisplayQueryChartResult(r models.QueryChartResult) error {
 
 	err = r.SaveImageAs(file.Name())
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	cmd := exec.Command("firefox", file.Name())
 	return cmd.Run()

--- a/examples/device_labels_example_test.go
+++ b/examples/device_labels_example_test.go
@@ -1,6 +1,7 @@
 //go:build examples
 // +build examples
 
+//nolint:testpackage,forbidigo
 package examples
 
 import (

--- a/examples/devices_example_test.go
+++ b/examples/devices_example_test.go
@@ -1,6 +1,7 @@
 //go:build examples
 // +build examples
 
+//nolint:testpackage,forbidigo
 package examples
 
 import (

--- a/examples/my_kentik_portal_example_test.go
+++ b/examples/my_kentik_portal_example_test.go
@@ -1,6 +1,7 @@
 //go:build examples
 // +build examples
 
+//nolint:testpackage,forbidigo
 package examples
 
 import (
@@ -8,7 +9,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/kentik/community_sdk_golang/kentikapi/models"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -23,10 +23,11 @@ func runCRUDExample() error {
 	if err != nil {
 		return err
 	}
-	var tenant_id models.ID = 577
+	// TODO(mpalczynski): pick tenantID from a list of all tenants
+	tenantID := 577
 
 	fmt.Println("### GET")
-	tenant, err := client.MyKentikPortal.Get(context.Background(), tenant_id)
+	tenant, err := client.MyKentikPortal.Get(context.Background(), tenantID)
 	if err != nil {
 		return err
 	}
@@ -34,7 +35,7 @@ func runCRUDExample() error {
 	PrettyPrint(tenant)
 
 	fmt.Println("### CREATE USER")
-	user, err := client.MyKentikPortal.CreateTenantUser(context.Background(), tenant_id, "test1@user.com")
+	user, err := client.MyKentikPortal.CreateTenantUser(context.Background(), tenantID, "test1@user.com")
 	if err != nil {
 		return err
 	}
@@ -42,7 +43,7 @@ func runCRUDExample() error {
 	PrettyPrint(user)
 
 	fmt.Println("### DELETE USER")
-	err = client.MyKentikPortal.DeleteTenantUser(context.Background(), tenant_id, user.ID)
+	err = client.MyKentikPortal.DeleteTenantUser(context.Background(), tenantID, user.ID)
 	if err != nil {
 		return err
 	}

--- a/examples/plans_example_test.go
+++ b/examples/plans_example_test.go
@@ -1,6 +1,7 @@
 //go:build examples
 // +build examples
 
+//nolint:testpackage,forbidigo
 package examples
 
 import (

--- a/examples/query_example_test.go
+++ b/examples/query_example_test.go
@@ -62,9 +62,7 @@ func runQueryData() error {
 	}
 
 	fmt.Println("### QUERY Data")
-	queryObject := makeQueryObject()
-
-	result, err := client.Query.Data(context.Background(), queryObject)
+	result, err := client.Query.Data(context.Background(), makeQueryObject())
 	if err != nil {
 		return err
 	}
@@ -143,9 +141,7 @@ func runQueryURL() error {
 	}
 
 	fmt.Println("### QUERY URL")
-	queryObject := makeQueryObject()
-
-	result, err := client.Query.URL(context.Background(), queryObject)
+	result, err := client.Query.URL(context.Background(), makeQueryObject())
 	if err != nil {
 		return err
 	}

--- a/examples/saved_filters_example_test.go
+++ b/examples/saved_filters_example_test.go
@@ -1,6 +1,7 @@
 //go:build examples
 // +build examples
 
+//nolint:testpackage,forbidigo
 package examples
 
 import (
@@ -92,7 +93,7 @@ func runCRUDSavedFilters() error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Succesfully deleted Saved Filter: %v\n", savedFilter.ID)
+	fmt.Printf("Successfully deleted Saved Filter: %v\n", savedFilter.ID)
 	fmt.Println()
 
 	return nil

--- a/examples/sites_example_test.go
+++ b/examples/sites_example_test.go
@@ -1,6 +1,7 @@
 //go:build examples
 // +build examples
 
+//nolint:testpackage,forbidigo
 package examples
 
 import (

--- a/examples/synthetics_example_test.go
+++ b/examples/synthetics_example_test.go
@@ -1,6 +1,7 @@
 //go:build examples
 // +build examples
 
+//nolint:testpackage,forbidigo
 package examples
 
 import (
@@ -272,14 +273,14 @@ func runGRPCCRUDAgent(ctx context.Context, client *kentikapi.Client) error {
 	fmt.Println()
 
 	// NOTE: as we can't create agents through the API - let's not delete them
-	//fmt.Println("### DELETE AGENT")
-	//deleteReqPayLoad := &syntheticspb.DeleteAgentRequest{Id: agentID}
-	//_, err = client.SyntheticsAdmin.DeleteAgent(ctx, deleteReqPayLoad)
-	//if err != nil {
-	//	return err
-	//}
-	//fmt.Println("Success")
-	//fmt.Println()
+	// fmt.Println("### DELETE AGENT")
+	// deleteReqPayLoad := &syntheticspb.DeleteAgentRequest{Id: agentID}
+	// _, err = client.SyntheticsAdmin.DeleteAgent(ctx, deleteReqPayLoad)
+	// if err != nil {
+	// 	return err
+	// }
+	// fmt.Println("Success")
+	// fmt.Println()
 
 	return nil
 }

--- a/examples/synthetics_mesh_example_test.go
+++ b/examples/synthetics_mesh_example_test.go
@@ -7,7 +7,6 @@ package examples
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"strconv"
 	"testing"
@@ -30,11 +29,15 @@ func runGetMeshTestResultsGRPC() error {
 	}
 
 	mesh, err := getMeshTestResultsGRPC(testID)
+	if err != nil {
+		return err
+	}
+
 	if mesh == nil {
 		fmt.Println("Empty mesh test result received")
 	} else {
 		metricsMatrix := newMetricsMatrixGRPC(mesh)
-		printMetricsMatrixGRPC(metricsMatrix)
+		err = printMetricsMatrixGRPC(metricsMatrix)
 	}
 
 	return err
@@ -71,7 +74,7 @@ func getMeshTestResultsGRPC(testID string) ([]*syntheticspb.MeshResponse, error)
 	return nil, nil
 }
 
-func printMetricsMatrixGRPC(matrix metricsMatrixGRPC) {
+func printMetricsMatrixGRPC(matrix metricsMatrixGRPC) error {
 	w := makeTabWriterGRPC()
 
 	// print table header
@@ -95,8 +98,9 @@ func printMetricsMatrixGRPC(matrix metricsMatrixGRPC) {
 	}
 
 	if err := w.Flush(); err != nil {
-		log.Fatal(err)
+		return err
 	}
+	return nil
 }
 
 func makeTabWriterGRPC() *tabwriter.Writer {

--- a/examples/tags_example_test.go
+++ b/examples/tags_example_test.go
@@ -1,6 +1,7 @@
 //go:build examples
 // +build examples
 
+//nolint:testpackage,forbidigo
 package examples
 
 import (

--- a/examples/users_example_test.go
+++ b/examples/users_example_test.go
@@ -1,6 +1,7 @@
 //go:build examples
 // +build examples
 
+//nolint:testpackage,forbidigo
 package examples
 
 import (

--- a/examples/utils.go
+++ b/examples/utils.go
@@ -1,3 +1,4 @@
+//nolint:forbidigo
 package examples
 
 import (
@@ -9,7 +10,7 @@ import (
 	"github.com/kentik/community_sdk_golang/kentikapi"
 )
 
-// ReadCredentialsFromEnv reads and returns (email, token) pair from environment variables, or error if not set
+// ReadCredentialsFromEnv reads and returns (email, token) pair from environment variables, or error if not set.
 func ReadCredentialsFromEnv() (authEmail, authToken string, _ error) {
 	authEmail, ok := os.LookupEnv("KTAPI_AUTH_EMAIL")
 	if !ok || authEmail == "" {
@@ -24,7 +25,7 @@ func ReadCredentialsFromEnv() (authEmail, authToken string, _ error) {
 	return authEmail, authToken, nil
 }
 
-// NewClient creates kentikapi client with credentials read from env variables
+// NewClient creates kentikapi client with credentials read from env variables.
 func NewClient() (*kentikapi.Client, error) {
 	email, token, err := ReadCredentialsFromEnv()
 	PanicOnError(err)
@@ -39,21 +40,21 @@ func NewClient() (*kentikapi.Client, error) {
 	return client, nil
 }
 
-// PanicOnError converts err into panic; use it to reduce the number of: "if err != nil { return err }" statements
+// PanicOnError converts err into panic; use it to reduce the number of: "if err != nil { return err }" statements.
 func PanicOnError(err error) {
 	if err != nil {
 		panic(err)
 	}
 }
 
-// PrettyPrint prints an object recursively in an indented way
+// PrettyPrint prints an object recursively in an indented way.
 func PrettyPrint(resource interface{}) {
 	prettyPrintRecursively(reflect.TypeOf(resource), reflect.ValueOf(resource), 0)
 }
 
+//nolint:gocyclo
 func prettyPrintRecursively(t reflect.Type, v reflect.Value, level int) {
 	switch v.Kind() {
-
 	case reflect.Struct:
 		if _, hasStringer := t.MethodByName("String"); hasStringer {
 			prettyPrintIndented("%v\n", level, v)
@@ -95,6 +96,7 @@ func prettyPrintRecursively(t reflect.Type, v reflect.Value, level int) {
 	}
 }
 
+//nolint:gomnd
 func prettyPrintIndented(format string, level int, args ...interface{}) {
 	fmt.Printf("%*s", level*2, "")
 	fmt.Printf(format, args...)

--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,11 @@ go 1.15
 
 require (
 	github.com/antchfx/jsonquery v1.1.4
-	github.com/gorilla/mux v1.8.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.6.0 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.0
 	github.com/kentik/api-schema-public v0.0.0-20211011204132-acc22cb40b78
 	github.com/stretchr/testify v1.7.0
-	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f
 	google.golang.org/genproto v0.0.0-20211005153810-c76a74d43a8e // indirect
 	google.golang.org/grpc v1.41.0
 	google.golang.org/protobuf v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,6 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
-github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
-github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
@@ -268,7 +266,6 @@ golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
-golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f h1:Qmd2pbz05z7z6lm0DrgQVVPuBm92jqujBKMHMOlOQEw=
 golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -398,7 +395,6 @@ google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
-google.golang.org/appengine v1.6.6 h1:lMO5rYAqUxkmaj76jAkRUvt5JZgFymx/+Q5Mzfivuhc=
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=


### PR DESCRIPTION
Issue: KNTK-359
Turned on linters in examples directory.
Explicitly defined superlinter version since the newest one introduced a bug.

Rundown for linters turned off by `nolint` directive:
- Testpackage: Examples directory are not tests per se - they only use their form.
- Forbidigo: it makes sense for examples to print messages to user
- Gomnd: it makes sense for examples to use explicit values
- Misspell: turns out I can't spell "successfully"
- Gocyclo: task performed by prettyPrintRecursively() is of complex nature
- Gochecknoglobals: I think these globals are pretty clever