### PR TITLE
Bash scripts colors methods refactored

### DIFF
--- a/examples/run_example.sh
+++ b/examples/run_example.sh
@@ -1,17 +1,18 @@
 #!/usr/bin/env bash
 
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+REPO_DIR=$(cd -- "$SCRIPT_DIR" && cd ../ && pwd)
+
+source "$REPO_DIR/tools/utility_functions.sh" || exit 1
+
 # INPUT:
 #   [none] - run all examples
 #   User
 #   Device
 
 function stage() {
-    BLUE_BOLD="\e[1m\e[34m"
-    RESET="\e[0m"
-    msg="$1"
-
     echo
-    echo -e "$BLUE_BOLD$msg$RESET"
+    colored_echo BOLD_BLUE "$1"
 }
 
 if [[ $1 != "" ]]; then

--- a/examples/run_example.sh
+++ b/examples/run_example.sh
@@ -1,24 +1,14 @@
 #!/usr/bin/env bash
 
-SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
-REPO_DIR=$(cd -- "$SCRIPT_DIR" && cd ../ && pwd)
-
-source "$REPO_DIR/tools/utility_functions.sh" || exit 1
-
 # INPUT:
 #   [none] - run all examples
 #   User
 #   Device
 
-function stage() {
-    echo
-    colored_echo BOLD_BLUE "$1"
-}
-
 if [[ $1 != "" ]]; then
-    stage "Running single example: $1"
+    echo "Running single example: $1"
     go test -tags examples -count 1 -run "$1"  ./... -v
 else
-    stage "Running all examples"
+    echo "Running all examples"
     go test -tags examples -count 1 ./... -v
 fi

--- a/kentikapi/gen_enum.sh
+++ b/kentikapi/gen_enum.sh
@@ -5,10 +5,6 @@ REPO_DIR=$(cd -- "$SCRIPT_DIR" && cd ../ && pwd)
 
 source "$REPO_DIR/tools/utility_functions.sh" || exit 1
 
-function stage() {
-    colored_echo CYAN "$1"
-}
-
 function checkPrerequsites() {
     stage "Checking prerequisites"
 

--- a/kentikapi/gen_enum.sh
+++ b/kentikapi/gen_enum.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-function stage() {
-    COLOR="\e[95m"
-    RESET="\e[0m"
-    msg="$1"
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+REPO_DIR=$(cd -- "$SCRIPT_DIR" && cd ../ && pwd)
 
-    echo
-    echo -e "$COLOR$msg$RESET"
+source "$REPO_DIR/tools/utility_functions.sh" || exit 1
+
+function stage() {
+    colored_echo CYAN "$1"
 }
 
 function checkPrerequsites() {

--- a/tools/utility_functions.sh
+++ b/tools/utility_functions.sh
@@ -24,7 +24,6 @@ function colored_echo() {
             BOLD_BLUE="\e[1m\e[96m"
             RED="\e[31m"
             YELLOW="\e[33m"
-            CYAN="\e[95m"
         }
         RESET="\e[0m"
         color_code=$(eval echo "\$$color")

--- a/tools/utility_functions.sh
+++ b/tools/utility_functions.sh
@@ -24,6 +24,7 @@ function colored_echo() {
             BOLD_BLUE="\e[1m\e[96m"
             RED="\e[31m"
             YELLOW="\e[33m"
+            CYAN="\e[95m"
         }
         RESET="\e[0m"
         color_code=$(eval echo "\$$color")


### PR DESCRIPTION
Issue: KNTK-288
Color codes used in Kentik open source repositories are broken on MacOS. 
Changed stage() methods to use same colored_echo() method.