### PR TITLE
Refactor examples and Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ export KTAPI_AUTH_TOKEN=<Kentik API authentication token>
 go test -tags examples -count 1 -parallel 1 -v -run Users github.com/kentik/community_sdk_golang/examples
 ```
 
-To configure timeout for a client call for Cloud Export or Synthetics use _context.WithTimeout()_ and pass it to the request function. See [an example](examples/cloud_export_example_test.go).
-
 ## Development
 
 Anybody who wants to contribute to development is welcome to provide pull requests. To work on the SDK, install tools listed in [requirements section](#requirements).
@@ -50,7 +48,7 @@ Optional tools:
 - _golangci-lint_: <https://golangci-lint.run/usage/install/#local-installation>
 
 Development steps:
-- Compile the code: `go build ./...`
+- Compile the code: `go build -tags examples ./...`
 - Run tests: `go test ./...`
 - Run all tests, including usage examples: `go test -tags examples ./...`
 - Run golangci-lint: `golangci-lint run ./...`

--- a/examples/demos/client_merge_demo/main.go
+++ b/examples/demos/client_merge_demo/main.go
@@ -3,14 +3,11 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
-	"os"
 
 	syntheticspb "github.com/kentik/api-schema-public/gen/go/kentik/synthetics/v202101beta1"
 	"github.com/kentik/community_sdk_golang/examples/demos"
-	"github.com/kentik/community_sdk_golang/kentikapi"
 )
 
 func main() {
@@ -20,25 +17,15 @@ func main() {
 }
 
 func showClientMerge() error {
-	demos.Step("Using Kentik API server")
-
-	email, token, err := ReadCredentialsFromEnv()
-	if err != nil {
-		return err
-	}
-
 	demos.Step("Create Kentik API client")
-
-	c, err := kentikapi.NewClient(kentikapi.Config{
-		AuthEmail: email,
-		AuthToken: token,
-	})
+	ctx := context.Background()
+	client, err := demos.NewClient()
 	if err != nil {
 		return err
 	}
 
 	demos.Step("List users using API v5")
-	result, err := c.Users.GetAll(context.Background())
+	result, err := client.Users.GetAll(ctx)
 	if err != nil {
 		return err
 	}
@@ -47,24 +34,10 @@ func showClientMerge() error {
 	demos.PrettyPrint(result)
 
 	demos.Step("List agents using API v6")
-	getResp, err := c.SyntheticsAdmin.ListAgents(context.Background(), &syntheticspb.ListAgentsRequest{})
+	getResp, err := client.SyntheticsAdmin.ListAgents(ctx, &syntheticspb.ListAgentsRequest{})
 
 	fmt.Println("Received result:")
 	demos.PrettyPrint(getResp.GetAgents())
 
 	return err
-}
-
-func ReadCredentialsFromEnv() (authEmail, authToken string, _ error) {
-	authEmail, ok := os.LookupEnv("KTAPI_AUTH_EMAIL")
-	if !ok || authEmail == "" {
-		return "", "", errors.New("KTAPI_AUTH_EMAIL environment variable needs to be set")
-	}
-
-	authToken, ok = os.LookupEnv("KTAPI_AUTH_TOKEN")
-	if !ok || authToken == "" {
-		return "", "", errors.New("KTAPI_AUTH_TOKEN environment variable needs to be set")
-	}
-
-	return authEmail, authToken, nil
 }

--- a/examples/demos/devices_users_demo/main.go
+++ b/examples/demos/devices_users_demo/main.go
@@ -13,6 +13,7 @@ import (
 )
 
 func main() {
+	demos.Step("Create Kentik API client")
 	client, err := demos.NewClient()
 	if err != nil {
 		log.Fatal(err)

--- a/examples/demos/grpc_synthetics_demo/main.go
+++ b/examples/demos/grpc_synthetics_demo/main.go
@@ -5,12 +5,9 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"time"
 
 	synthetics "github.com/kentik/api-schema-public/gen/go/kentik/synthetics/v202101beta1"
-	"github.com/kentik/community_sdk_golang/examples"
 	"github.com/kentik/community_sdk_golang/examples/demos"
-	"github.com/kentik/community_sdk_golang/kentikapi"
 )
 
 func main() {
@@ -19,27 +16,16 @@ func main() {
 	}
 }
 
-//nolint:gomnd
 func showGRPCClient() error {
-	email, token, err := examples.ReadCredentialsFromEnv()
+	demos.Step("Create Kentik API client")
+	ctx := context.Background()
+	client, err := demos.NewClient()
 	if err != nil {
 		return err
 	}
 
-	demos.Step("Create Kentik API gRPC client")
-
-	c, err := kentikapi.NewClient(kentikapi.Config{
-		AuthEmail: email,
-		AuthToken: token,
-	})
-	if err != nil {
-		log.Fatalln(err)
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Second)
-	defer cancel()
-
 	demos.Step("List synthetic agents")
-	result, err := c.SyntheticsAdmin.ListAgents(ctx, &synthetics.ListAgentsRequest{})
+	result, err := client.SyntheticsAdmin.ListAgents(ctx, &synthetics.ListAgentsRequest{})
 
 	fmt.Println("Received result:")
 	demos.PrettyPrint(result.GetAgents())

--- a/examples/demos/interfaces_query_demo/main.go
+++ b/examples/demos/interfaces_query_demo/main.go
@@ -13,6 +13,7 @@ import (
 )
 
 func main() {
+	demos.Step("Create Kentik API client")
 	client, err := demos.NewClient()
 	if err != nil {
 		log.Fatal(err)

--- a/examples/demos/utils.go
+++ b/examples/demos/utils.go
@@ -16,12 +16,11 @@ import (
 
 //nolint:gochecknoglobals
 var (
-	ExitOnError = examples.PanicOnError
-	PrettyPrint = examples.PrettyPrint
 	NewClient   = examples.NewClient
+	PrettyPrint = examples.PrettyPrint
 )
 
-// untypedData allows trawersing untyped structures made of maps and slices.
+// untypedData allows traversing untyped structures made of maps and slices.
 type untypedData struct {
 	V interface{}
 }
@@ -53,6 +52,13 @@ func Step(msg string) {
 	fmt.Printf("Press enter to continue...")
 	if _, err := fmt.Scanln(); err != nil {
 		log.Print(err)
+	}
+}
+
+// ExitOnError converts err into panic; use it to reduce the number of: "if err != nil { return err }" statements.
+func ExitOnError(err error) {
+	if err != nil {
+		panic(err)
 	}
 }
 
@@ -90,7 +96,7 @@ func DisplayQueryDataResult(r models.QueryDataResult) error {
 	return nil
 }
 
-// makeTabWriter prepares tabwriter for writing file list in form: Name  Size  Type.
+// makeTabWriter prepares tab writer for writing file list in form: Name  Size  Type.
 func makeTabWriter() *tabwriter.Writer {
 	const minWidth = 0  // minimal cell width including any padding
 	const tabWidth = 2  // width of tab characters (equivalent number of spaces)

--- a/examples/my_kentik_portal_example_test.go
+++ b/examples/my_kentik_portal_example_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/kentik/community_sdk_golang/kentikapi/models"
 	"github.com/stretchr/testify/assert"
@@ -72,12 +71,11 @@ func getAllTenants() error {
 }
 
 func pickTenantID() (models.ID, error) {
+	ctx := context.Background()
 	client, err := NewClient()
 	if err != nil {
 		return 0, err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
-	defer cancel()
 
 	tenants, err := client.MyKentikPortal.GetAll(ctx)
 	if err != nil {

--- a/examples/synthetics_example_test.go
+++ b/examples/synthetics_example_test.go
@@ -24,13 +24,11 @@ func TestSyntheticsAPIExample(t *testing.T) {
 }
 
 func runAdminServiceExamples() error {
+	ctx := context.Background()
 	client, err := NewClient()
 	if err != nil {
 		return err
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
-	defer cancel()
 
 	if err = runCRUDTest(ctx, client); err != nil {
 		fmt.Println(err)
@@ -56,18 +54,17 @@ func runAdminServiceExamples() error {
 }
 
 func runDataServiceExamples() error {
+	ctx := context.Background()
+
 	client, err := NewClient()
 	if err != nil {
 		return err
 	}
 
-	testID, err := pickTestID()
+	testID, err := pickTestID(ctx)
 	if err != nil {
 		return err
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
-	defer cancel()
 
 	if err = runGetHealthForTest(ctx, client, testID); err != nil {
 		fmt.Println(err)
@@ -386,12 +383,11 @@ func makeExampleTest() *syntheticspb.Test {
 }
 
 func pickAgentID() (string, error) {
+	ctx := context.Background()
 	client, err := NewClient()
 	if err != nil {
 		return "", err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
-	defer cancel()
 
 	getAllResp, err := client.SyntheticsAdmin.ListAgents(ctx, &syntheticspb.ListAgentsRequest{})
 	if err != nil {

--- a/examples/synthetics_mesh_example_test.go
+++ b/examples/synthetics_mesh_example_test.go
@@ -24,7 +24,9 @@ func TestGetMeshTestResultsExample(t *testing.T) {
 }
 
 func runGetMeshTestResults() error {
-	testID, err := pickTestID()
+	ctx := context.Background()
+
+	testID, err := pickTestID(ctx)
 	if err != nil {
 		return err
 	}
@@ -156,13 +158,11 @@ func (m metricsMatrix) getMetric(fromAgent string, toAgent string) (*syntheticsp
 	return metric, true
 }
 
-func pickTestID() (string, error) {
+func pickTestID(ctx context.Context) (string, error) {
 	client, err := NewClient()
 	if err != nil {
 		return "", err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
-	defer cancel()
 
 	getAllResp, err := client.SyntheticsAdmin.ListTests(ctx, &syntheticspb.ListTestsRequest{})
 	if err != nil {
@@ -176,5 +176,5 @@ func pickTestID() (string, error) {
 			}
 		}
 	}
-	return "", fmt.Errorf("No tests with type application_mesh for requested Kentik account: %v", err)
+	return "", fmt.Errorf("no tests with type application_mesh for requested Kentik account: %v", err)
 }

--- a/examples/users_example_test.go
+++ b/examples/users_example_test.go
@@ -13,28 +13,29 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDemonstrateUsersCRUD(t *testing.T) {
+func TestDemonstrateUsersAPI(t *testing.T) {
 	t.Parallel()
-	err := demonstrateUsersCRUD()
+	err := demonstrateUsersAPI()
 	assert.NoError(t, err)
 }
 
-func TestDemonstrateUsersGetAll(t *testing.T) {
-	t.Parallel()
-	err := demonstrateUsersGetAll()
-	assert.NoError(t, err)
-}
-
-func demonstrateUsersCRUD() error {
+func demonstrateUsersAPI() error {
 	ctx := context.Background()
 	client, err := NewClient()
 	if err != nil {
 		return err
 	}
 
-	fmt.Println("### client.Users.Create")
+	fmt.Println("Invoking client.Users.GetAll")
+	users, err := client.Users.GetAll(ctx)
+	if err != nil {
+		return fmt.Errorf("client.Users.GetAll: %w", err)
+	}
+	PrettyPrint(users)
+
+	fmt.Println("Invoking client.Users.Create")
 	user, err := client.Users.Create(ctx, *models.NewUser(models.UserRequiredFields{
-		Username:     "testuser",
+		Username:     "test-user",
 		UserFullName: "Test User",
 		UserEmail:    "test@user.example",
 		Role:         "Member",
@@ -42,54 +43,38 @@ func demonstrateUsersCRUD() error {
 		EmailProduct: true,
 	}))
 	if err != nil {
-		return fmt.Errorf("client.Users.Create failed: %w", err)
+		return fmt.Errorf("client.Users.Create: %w", err)
 	}
 
 	PrettyPrint(user)
 	fmt.Println()
 
-	fmt.Println("### client.Users.Get")
+	fmt.Println("Invoking client.Users.Get")
 	user, err = client.Users.Get(ctx, user.ID)
 	if err != nil {
-		return fmt.Errorf("client.Users.Get failed: %w", err)
+		return fmt.Errorf("client.Users.Get: %w", err)
 	}
 
 	PrettyPrint(user)
 	fmt.Println()
 
-	fmt.Println("### client.Users.Update")
+	fmt.Println("Invoking client.Users.Update")
 	user.UserFullName = "Updated User"
 	user.EmailProduct = false
 	user, err = client.Users.Update(ctx, *user)
 	if err != nil {
-		return fmt.Errorf("client.Users.Update failed: %w", err)
+		return fmt.Errorf("client.Users.Update: %w", err)
 	}
 
 	PrettyPrint(user)
 	fmt.Println()
 
-	fmt.Println("### client.Users.Delete")
-	err = client.Users.Delete(context.Background(), user.ID)
+	fmt.Println("Invoking client.Users.Delete")
+	err = client.Users.Delete(ctx, user.ID)
 	if err != nil {
-		return fmt.Errorf("client.Users.Delete failed: %w", err)
+		return fmt.Errorf("client.Users.Delete: %w", err)
 	}
 
-	return nil
-}
-
-func demonstrateUsersGetAll() error {
-	ctx := context.Background()
-	client, err := NewClient()
-	if err != nil {
-		return err
-	}
-
-	fmt.Println("### client.Users.GetAll")
-	users, err := client.Users.GetAll(ctx)
-	if err != nil {
-		return fmt.Errorf("client.Users.GetAll failed: %w", err)
-	}
-	PrettyPrint(users)
-
+	fmt.Println("client.Users.Delete succeeded")
 	return nil
 }

--- a/examples/utils.go
+++ b/examples/utils.go
@@ -25,10 +25,12 @@ func ReadCredentialsFromEnv() (authEmail, authToken string, _ error) {
 	return authEmail, authToken, nil
 }
 
-// NewClient creates kentikapi client with credentials read from env variables.
+// NewClient creates Kentik API client with credentials read from environment variables.
 func NewClient() (*kentikapi.Client, error) {
 	email, token, err := ReadCredentialsFromEnv()
-	PanicOnError(err)
+	if err != nil {
+		return nil, err
+	}
 
 	client, err := kentikapi.NewClient(kentikapi.Config{
 		AuthEmail: email,
@@ -38,13 +40,6 @@ func NewClient() (*kentikapi.Client, error) {
 		return nil, err
 	}
 	return client, nil
-}
-
-// PanicOnError converts err into panic; use it to reduce the number of: "if err != nil { return err }" statements.
-func PanicOnError(err error) {
-	if err != nil {
-		panic(err)
-	}
 }
 
 // PrettyPrint prints an object recursively in an indented way.

--- a/kentikapi/internal/api_connection/rest_client.go
+++ b/kentikapi/internal/api_connection/rest_client.go
@@ -76,7 +76,8 @@ func (c *RestClient) Get(ctx context.Context, path string) (responseBody json.Ra
 
 // Post sends POST request to the API and returns raw response body
 //nolint:dupl
-func (c *RestClient) Post(ctx context.Context, path string, payload json.RawMessage,
+func (c *RestClient) Post(
+	ctx context.Context, path string, payload json.RawMessage,
 ) (responseBody json.RawMessage, err error) {
 	ctx, cancel := context.WithTimeout(ctx, *c.config.Timeout)
 	defer cancel()
@@ -107,7 +108,8 @@ func (c *RestClient) Post(ctx context.Context, path string, payload json.RawMess
 
 // Put sends PUT request to the API and returns raw response body
 //nolint:dupl
-func (c *RestClient) Put(ctx context.Context, path string, payload json.RawMessage,
+func (c *RestClient) Put(
+	ctx context.Context, path string, payload json.RawMessage,
 ) (responseBody json.RawMessage, err error) {
 	ctx, cancel := context.WithTimeout(ctx, *c.config.Timeout)
 	defer cancel()

--- a/kentikapi/models/user.go
+++ b/kentikapi/models/user.go
@@ -4,7 +4,7 @@ import "time"
 
 // User model.
 type User struct {
-	// read-write properties (can be updated in update call)
+	// read-write properties
 	Username     string
 	UserFullName string
 	UserEmail    string
@@ -13,7 +13,7 @@ type User struct {
 	EmailService bool
 	EmailProduct bool
 
-	// read-only properties (can't be updated in update call)
+	// read-only properties
 	ID           ID
 	LastLogin    *time.Time
 	CreatedDate  time.Time


### PR DESCRIPTION
Refactors extracted from API v6 transformation
Remove context.WithTimeout from examples, because API v6 supports
client-level timeout now, so context timeout is not needed.

Issue: KNTK-372
