### PR TITLE
Limit logged payloads size

### DIFF
--- a/examples/demos/retry_apiv5_demo/main.go
+++ b/examples/demos/retry_apiv5_demo/main.go
@@ -51,6 +51,7 @@ func showRetryingOnMultipleCodes() error {
 			MinDelay:    pointer.ToDuration(1 * time.Second),
 			MaxDelay:    pointer.ToDuration(2 * time.Second),
 		},
+		LogPayloads: true,
 	})
 	if err != nil {
 		return err

--- a/kentikapi/client_integration_test.go
+++ b/kentikapi/client_integration_test.go
@@ -136,7 +136,8 @@ func TestClient_GetUserWithRetries(t *testing.T) {
 					MinDelay: pointer.ToDuration(1 * time.Microsecond),
 					MaxDelay: pointer.ToDuration(10 * time.Microsecond),
 				},
-				Timeout: tt.timeout,
+				Timeout:     tt.timeout,
+				LogPayloads: true,
 			})
 			assert.NoError(t, err)
 
@@ -292,7 +293,8 @@ func TestClient_GetAgentWithRetries(t *testing.T) {
 					MaxAttempts: tt.retryMax,
 					MinDelay:    pointer.ToDuration(10 * time.Microsecond),
 				},
-				Timeout: tt.timeout,
+				Timeout:     tt.timeout,
+				LogPayloads: true,
 			})
 			require.NoError(t, err)
 

--- a/kentikapi/cloud_exports_integration_test.go
+++ b/kentikapi/cloud_exports_integration_test.go
@@ -108,9 +108,10 @@ func TestClient_GetAllCloudExports(t *testing.T) {
 			server.Start()
 			defer server.Stop()
 			client, err := kentikapi.NewClient(kentikapi.Config{
-				APIURL:    "http://" + server.url,
-				AuthToken: dummyAuthToken,
-				AuthEmail: dummyAuthEmail,
+				APIURL:      "http://" + server.url,
+				AuthToken:   dummyAuthToken,
+				AuthEmail:   dummyAuthEmail,
+				LogPayloads: true,
 			})
 			require.NoError(t, err)
 
@@ -276,9 +277,10 @@ func TestClient_GetCloudExport(t *testing.T) {
 			defer server.Stop()
 
 			client, err := kentikapi.NewClient(kentikapi.Config{
-				APIURL:    "http://" + server.url,
-				AuthToken: dummyAuthToken,
-				AuthEmail: dummyAuthEmail,
+				APIURL:      "http://" + server.url,
+				AuthToken:   dummyAuthToken,
+				AuthEmail:   dummyAuthEmail,
+				LogPayloads: true,
 			})
 			require.NoError(t, err)
 
@@ -498,9 +500,10 @@ func TestClient_CreateCloudExport(t *testing.T) {
 			defer server.Stop()
 
 			client, err := kentikapi.NewClient(kentikapi.Config{
-				APIURL:    "http://" + server.url,
-				AuthToken: dummyAuthToken,
-				AuthEmail: dummyAuthEmail,
+				APIURL:      "http://" + server.url,
+				AuthToken:   dummyAuthToken,
+				AuthEmail:   dummyAuthEmail,
+				LogPayloads: true,
 			})
 			require.NoError(t, err)
 
@@ -599,9 +602,10 @@ func TestClient_UpdateCloudExport(t *testing.T) {
 			defer server.Stop()
 
 			client, err := kentikapi.NewClient(kentikapi.Config{
-				APIURL:    "http://" + server.url,
-				AuthToken: dummyAuthToken,
-				AuthEmail: dummyAuthEmail,
+				APIURL:      "http://" + server.url,
+				AuthToken:   dummyAuthToken,
+				AuthEmail:   dummyAuthEmail,
+				LogPayloads: true,
 			})
 			require.NoError(t, err)
 
@@ -671,9 +675,10 @@ func TestClient_DeleteCloudExport(t *testing.T) {
 			defer server.Stop()
 
 			client, err := kentikapi.NewClient(kentikapi.Config{
-				APIURL:    "http://" + server.url,
-				AuthToken: dummyAuthToken,
-				AuthEmail: dummyAuthEmail,
+				APIURL:      "http://" + server.url,
+				AuthToken:   dummyAuthToken,
+				AuthEmail:   dummyAuthEmail,
+				LogPayloads: true,
 			})
 			require.NoError(t, err)
 

--- a/kentikapi/internal/resources/alerting_test.go
+++ b/kentikapi/internal/resources/alerting_test.go
@@ -17,7 +17,7 @@ var (
 	time2 = time.Date(2021, time.March, 19, 13, 50, 0, 0, time.Local)
 )
 
-func TestCrerateManualMitigation(t *testing.T) {
+func TestCreateManualMitigation(t *testing.T) {
 	createResponsePayload := `
 	{
 		"response": {

--- a/kentikapi/internal/resources/base.go
+++ b/kentikapi/internal/resources/base.go
@@ -1,10 +1,12 @@
 package resources
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/http"
 
 	"github.com/kentik/community_sdk_golang/kentikapi/internal/api_connection"
 	"github.com/kentik/community_sdk_golang/kentikapi/internal/validation"
@@ -16,12 +18,13 @@ type BaseAPI struct {
 	LogPayloads bool
 }
 
-// GetAndValidate retrieves json at "url", unmarshalls and validates against required fields defined in struct tags of "output"
-// output must be pointer to object or nil.
-func (b BaseAPI) GetAndValidate(ctx context.Context, url string, output interface{}) error {
-	b.logPayload("Kentik API request - GET", url, "")
-	responseBody, err := b.Transport.Get(ctx, url)
-	b.logPayload("Kentik API response - GET", url, responseBody)
+// GetAndValidate retrieves JSON at "path", unmarshalls and validates it against required fields
+// defined in struct tags of "output".
+// Output must be pointer to object or nil.
+func (b BaseAPI) GetAndValidate(ctx context.Context, path string, output interface{}) error {
+	b.logRequest(http.MethodGet, path, "")
+	responseBody, err := b.Transport.Get(ctx, path)
+	b.logResponse(http.MethodGet, path, string(responseBody), err)
 	if err != nil {
 		return err
 	}
@@ -42,20 +45,21 @@ func (b BaseAPI) GetAndValidate(ctx context.Context, url string, output interfac
 }
 
 // PostAndValidate validates input against required fields defined in struct tags of "input",
-// retrieves json at "url", unmarshalls and validates against required fields in "output"
-// output must be pointer to object or nil.
-func (b BaseAPI) PostAndValidate(ctx context.Context, url string, input interface{}, output interface{}) error {
+// retrieves JSON at "path", unmarshalls and validates against required fields in "output"
+// Output must be pointer to object or nil.
+//nolint: dupl
+func (b BaseAPI) PostAndValidate(ctx context.Context, path string, input interface{}, output interface{}) error {
 	if err := validation.CheckRequestRequiredFields("post", input); err != nil {
 		return err
 	}
 	payload, err := json.Marshal(input)
-	b.logPayload("Kentik API request - POST", url, payload)
 	if err != nil {
 		return fmt.Errorf("encode request body: %v", err)
 	}
 
-	responseBody, err := b.Transport.Post(ctx, url, payload)
-	b.logPayload("Kentik API response - POST", url, responseBody)
+	b.logRequest(http.MethodPost, path, string(payload))
+	responseBody, err := b.Transport.Post(ctx, path, payload)
+	b.logResponse(http.MethodPost, path, string(responseBody), err)
 	if err != nil {
 		return err
 	}
@@ -76,20 +80,21 @@ func (b BaseAPI) PostAndValidate(ctx context.Context, url string, input interfac
 }
 
 // UpdateAndValidate validates input against required fields defined in struct tags of "input",
-// retrieves json at "url", unmarshalls and validates against required fields in "output"
-// output must be pointer to object or nil.
-func (b BaseAPI) UpdateAndValidate(ctx context.Context, url string, input interface{}, output interface{}) error {
+// retrieves JSON at "path", unmarshalls and validates against required fields in "output"
+// Output must be pointer to object or nil.
+//nolint: dupl
+func (b BaseAPI) UpdateAndValidate(ctx context.Context, path string, input interface{}, output interface{}) error {
 	if err := validation.CheckRequestRequiredFields("put", input); err != nil {
 		return err
 	}
 	payload, err := json.Marshal(input)
-	b.logPayload("Kentik API request - PUT", url, payload)
 	if err != nil {
 		return fmt.Errorf("encode request body: %v", err)
 	}
 
-	responseBody, err := b.Transport.Put(ctx, url, payload)
-	b.logPayload("Kentik API response - PUT", url, responseBody)
+	b.logRequest(http.MethodPut, path, string(payload))
+	responseBody, err := b.Transport.Put(ctx, path, payload)
+	b.logResponse(http.MethodPut, path, string(responseBody), err)
 	if err != nil {
 		return err
 	}
@@ -109,13 +114,13 @@ func (b BaseAPI) UpdateAndValidate(ctx context.Context, url string, input interf
 	return nil
 }
 
-// DeleteAndValidate retrieves json at "url" unmarshalls and validates
+// DeleteAndValidate retrieves JSON at "path", unmarshalls and validates
 // against required fields defined in struct tags of "output"
-// output must be pointer to object or nil.
-func (b BaseAPI) DeleteAndValidate(ctx context.Context, url string, output interface{}) error {
-	b.logPayload("Kentik API request - DELETE", url, "")
-	responseBody, err := b.Transport.Delete(ctx, url)
-	b.logPayload("Kentik API response - DELETE", url, responseBody)
+// Output must be pointer to object or nil.
+func (b BaseAPI) DeleteAndValidate(ctx context.Context, path string, output interface{}) error {
+	b.logRequest(http.MethodDelete, path, "")
+	responseBody, err := b.Transport.Delete(ctx, path)
+	b.logResponse(http.MethodDelete, path, string(responseBody), err)
 	if err != nil {
 		return err
 	}
@@ -135,12 +140,42 @@ func (b BaseAPI) DeleteAndValidate(ctx context.Context, url string, output inter
 	return nil
 }
 
-func (b BaseAPI) logPayload(msg, url string, payload interface{}) {
+func (b BaseAPI) logRequest(method, path, payloadJSON string) {
 	if b.LogPayloads {
-		if payload == "" {
-			log.Printf("%s %s", msg, url)
-		} else {
-			log.Printf("%s %s - %s", msg, url, payload)
-		}
+		log.Printf("Kentik API request: method=%v path=%v payload=%v", method, path, sanitizePayload(payloadJSON))
 	}
+}
+
+func (b BaseAPI) logResponse(method, path, payloadJSON string, err error) {
+	if b.LogPayloads {
+		log.Printf(
+			"Kentik API response: method=%v path=%v payload=%v error=%v",
+			method, path, sanitizePayload(payloadJSON), err,
+		)
+	}
+}
+
+func sanitizePayload(payloadJSON string) string {
+	if payloadJSON == "" {
+		return "<empty>"
+	}
+
+	p := compactJSON([]byte(payloadJSON))
+
+	const maxLoggedPayloadSize = 10000
+	if len(p) > maxLoggedPayloadSize {
+		return fmt.Sprintf("<size: %v bytes>", len(p))
+	}
+	return p
+}
+
+// compactJSON makes unindented JSON from given JSON, if possible.
+func compactJSON(jsonS []byte) string {
+	var buffer bytes.Buffer
+	err := json.Compact(&buffer, jsonS)
+	if err != nil {
+		return string(jsonS)
+	}
+
+	return buffer.String()
 }

--- a/kentikapi/synth_agents_integration_test.go
+++ b/kentikapi/synth_agents_integration_test.go
@@ -68,9 +68,10 @@ func TestClient_GetAgent(t *testing.T) {
 			defer server.Stop()
 
 			client, err := kentikapi.NewClient(kentikapi.Config{
-				APIURL:    "http://" + server.url,
-				AuthToken: dummyAuthToken,
-				AuthEmail: dummyAuthEmail,
+				APIURL:      "http://" + server.url,
+				AuthToken:   dummyAuthToken,
+				AuthEmail:   dummyAuthEmail,
+				LogPayloads: true,
 			})
 			require.NoError(t, err)
 

--- a/kentikapi/tags_integration_test.go
+++ b/kentikapi/tags_integration_test.go
@@ -91,9 +91,10 @@ func TestClient_GetAllTags(t *testing.T) {
 			defer s.Close()
 
 			c, err := kentikapi.NewClient(kentikapi.Config{
-				APIURL:    s.URL,
-				AuthEmail: dummyAuthEmail,
-				AuthToken: dummyAuthToken,
+				APIURL:      s.URL,
+				AuthEmail:   dummyAuthEmail,
+				AuthToken:   dummyAuthToken,
+				LogPayloads: true,
 			})
 			assert.NoError(t, err)
 
@@ -160,9 +161,10 @@ func TestClient_GetTag(t *testing.T) {
 			defer s.Close()
 
 			c, err := kentikapi.NewClient(kentikapi.Config{
-				APIURL:    s.URL,
-				AuthEmail: dummyAuthEmail,
-				AuthToken: dummyAuthToken,
+				APIURL:      s.URL,
+				AuthEmail:   dummyAuthEmail,
+				AuthToken:   dummyAuthToken,
+				LogPayloads: true,
 			})
 			assert.NoError(t, err)
 
@@ -338,9 +340,10 @@ func TestClient_CreateTag(t *testing.T) {
 			defer s.Close()
 
 			c, err := kentikapi.NewClient(kentikapi.Config{
-				APIURL:    s.URL,
-				AuthEmail: dummyAuthEmail,
-				AuthToken: dummyAuthToken,
+				APIURL:      s.URL,
+				AuthEmail:   dummyAuthEmail,
+				AuthToken:   dummyAuthToken,
+				LogPayloads: true,
 			})
 			assert.NoError(t, err)
 
@@ -507,9 +510,10 @@ func TestClient_UpdateTag(t *testing.T) {
 			defer s.Close()
 
 			c, err := kentikapi.NewClient(kentikapi.Config{
-				APIURL:    s.URL,
-				AuthEmail: dummyAuthEmail,
-				AuthToken: dummyAuthToken,
+				APIURL:      s.URL,
+				AuthEmail:   dummyAuthEmail,
+				AuthToken:   dummyAuthToken,
+				LogPayloads: true,
 			})
 			assert.NoError(t, err)
 
@@ -568,9 +572,10 @@ func TestClient_DeleteTag(t *testing.T) {
 			defer s.Close()
 
 			c, err := kentikapi.NewClient(kentikapi.Config{
-				APIURL:    s.URL,
-				AuthEmail: dummyAuthEmail,
-				AuthToken: dummyAuthToken,
+				APIURL:      s.URL,
+				AuthEmail:   dummyAuthEmail,
+				AuthToken:   dummyAuthToken,
+				LogPayloads: true,
 			})
 			assert.NoError(t, err)
 

--- a/kentikapi/users_integration_test.go
+++ b/kentikapi/users_integration_test.go
@@ -167,9 +167,10 @@ func TestClient_GetAllUsers(t *testing.T) {
 			defer s.Close()
 
 			c, err := kentikapi.NewClient(kentikapi.Config{
-				APIURL:    s.URL,
-				AuthEmail: dummyAuthEmail,
-				AuthToken: dummyAuthToken,
+				APIURL:      s.URL,
+				AuthEmail:   dummyAuthEmail,
+				AuthToken:   dummyAuthToken,
+				LogPayloads: true,
 			})
 			assert.NoError(t, err)
 
@@ -264,9 +265,10 @@ func TestClient_GetUser(t *testing.T) {
 			defer s.Close()
 
 			c, err := kentikapi.NewClient(kentikapi.Config{
-				APIURL:    s.URL,
-				AuthEmail: dummyAuthEmail,
-				AuthToken: dummyAuthToken,
+				APIURL:      s.URL,
+				AuthEmail:   dummyAuthEmail,
+				AuthToken:   dummyAuthToken,
+				LogPayloads: true,
 			})
 			assert.NoError(t, err)
 
@@ -487,6 +489,7 @@ func TestClient_CreateUser(t *testing.T) {
 					MinDelay:    pointer.ToDuration(1 * time.Microsecond),
 					MaxDelay:    pointer.ToDuration(10 * time.Microsecond),
 				},
+				LogPayloads: true,
 			})
 			assert.NoError(t, err)
 
@@ -621,9 +624,10 @@ func TestClient_UpdateUser(t *testing.T) {
 			defer s.Close()
 
 			c, err := kentikapi.NewClient(kentikapi.Config{
-				APIURL:    s.URL,
-				AuthEmail: dummyAuthEmail,
-				AuthToken: dummyAuthToken,
+				APIURL:      s.URL,
+				AuthEmail:   dummyAuthEmail,
+				AuthToken:   dummyAuthToken,
+				LogPayloads: true,
 			})
 			assert.NoError(t, err)
 
@@ -682,9 +686,10 @@ func TestClient_DeleteUser(t *testing.T) {
 			defer s.Close()
 
 			c, err := kentikapi.NewClient(kentikapi.Config{
-				APIURL:    s.URL,
-				AuthEmail: dummyAuthEmail,
-				AuthToken: dummyAuthToken,
+				APIURL:      s.URL,
+				AuthEmail:   dummyAuthEmail,
+				AuthToken:   dummyAuthToken,
+				LogPayloads: true,
 			})
 			assert.NoError(t, err)
 


### PR DESCRIPTION
Additionaly, compact JSON payloads not to flood the console / files.
Information like response status codes are in err, which is also logged now.

Issue: KNTK-384
