### PR TITLE
Fix metric value formatting in network mesh test example

### DIFF
--- a/examples/synthetics_mesh_example_test.go
+++ b/examples/synthetics_mesh_example_test.go
@@ -295,18 +295,26 @@ func formatMetricData(md *syntheticspb.MetricData, isCurrentMeasurementValid boo
 
 	return fmt.Sprintf(
 		"%v / %v / %v / %v\t",
-		formatMetricValue(md.GetCurrent(), isCurrentMeasurementValid),
-		formatMetricValue(md.GetRollingAvg(), isCurrentMeasurementValid),
-		formatMetricValue(md.GetRollingStddev(), isCurrentMeasurementValid),
+		formatCurrentMetricValue(md.GetCurrent(), isCurrentMeasurementValid),
+		formatRollingMetricValue(md.GetRollingAvg()),
+		formatRollingMetricValue(md.GetRollingStddev()),
 		md.GetHealth(),
 	)
 }
 
-// formatMetricValue formats the value of metric given in nanoseconds to milliseconds.
-func formatMetricValue(metricValue uint32, isCurrentMeasurementValid bool) string {
-	if metricValue == 0 && !isCurrentMeasurementValid {
+func formatCurrentMetricValue(metricValue uint32, isCurrentMeasurementValid bool) string {
+	if !isCurrentMeasurementValid {
 		return "[X]"
 	}
+	return formatMetricValue(metricValue)
+}
+
+func formatRollingMetricValue(metricValue uint32) string {
+	return formatMetricValue(metricValue)
+}
+
+// formatMetric formats the value of metric given in nanoseconds to milliseconds.
+func formatMetricValue(metricValue uint32) string {
 	return strconv.Itoa(int(metricValue) / 1000)
 }
 

--- a/examples/synthetics_mesh_example_test.go
+++ b/examples/synthetics_mesh_example_test.go
@@ -312,5 +312,5 @@ func formatMetricValue(metricValue uint32, isCurrentMeasurementValid bool) strin
 
 // isCurrentMeasurementValid returns true if current ping packet loss is less than 100%.
 func isCurrentMeasurementValid(pr *syntheticspb.PingResults) bool {
-	return !(pr.GetPacketLoss().GetCurrent() == 1)
+	return pr.GetPacketLoss().GetCurrent() < 1
 }


### PR DESCRIPTION
Previously, code treated all 0 ns latency/jitter metrics are invalid. In
fact in some cases those are correct values and should be displayed as
"0 ms" to user. Those cases are for example:
- low latency rolling stddev.
- low jitter rolling stddev.
- ultra low current jitter

"0 ns" values are still treated as invalid when current packet loss is
100%.

Issue: KNTK-403
