### PR TITLE
RetryInterceptor codes extended

### DIFF
--- a/kentikapi/client.go
+++ b/kentikapi/client.go
@@ -268,7 +268,12 @@ func makeAuthInterceptor(c config) grpc.UnaryClientInterceptor {
 func makeRetryInterceptor(c config) grpc.UnaryClientInterceptor {
 	return grpcretry.UnaryClientInterceptor(
 		grpcretry.WithBackoff(grpcretry.BackoffExponential(*c.RetryCfg.MinDelay)),
-		grpcretry.WithCodes(codes.Unavailable),
+		grpcretry.WithCodes(
+			codes.Unavailable,
+			codes.ResourceExhausted,
+			codes.FailedPrecondition,
+			codes.Aborted,
+		),
 		// grpcretry.WithMax specifies the number of total requests sent and not retries
 		grpcretry.WithMax(*c.RetryCfg.MaxAttempts+1),
 	)


### PR DESCRIPTION
KNTK-404
Retry on: RESOURCE_EXHAUSTED (8), FAILED_PRECONDITION (9), ABORTED (10), UNAVAILABLE (14).