### PR TITLE
Move TestClient_Create retry test cases to client_integration_test.go

### DIFF
--- a/kentikapi/tags_integration_test.go
+++ b/kentikapi/tags_integration_test.go
@@ -330,6 +330,7 @@ func TestClient_CreateTag(t *testing.T) {
 			expectedResult: newTestTagOne(t),
 		},
 	}
+	// nolint: dupl
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// arrange


### PR DESCRIPTION
Tests of the library mechanisms are placed in
client_integration_test.go. Tests of retry mechanism also belong to that
group.
